### PR TITLE
transactions for different networks

### DIFF
--- a/src/ts/background/store/transaction/actions.ts
+++ b/src/ts/background/store/transaction/actions.ts
@@ -25,14 +25,14 @@ export const ACTION_TYPES = {
 
 const PREFIX = 'transactions_'
 
-export function getTransactions (address: string): AnyAction {
+export function getTransactions (address: string, network: string): AnyAction {
   return {
     type: ACTION_TYPES.GET_TRANSACTIONS,
-    payload: LocalStore.getValue(PREFIX + address)
+    payload: LocalStore.getValue(PREFIX + address + '_' + network)
   }
 }
 
-export function upsertTransaction (address: string,
+export function upsertTransaction (address: string, network: string,
                                    tran: ITransaction, list: ITransaction[]): AnyAction {
   const idx = list.findIndex(item => item.txHash === tran.txHash)
   let updated = [tran]
@@ -45,13 +45,14 @@ export function upsertTransaction (address: string,
   }
   return {
     type: ACTION_TYPES.UPSERT_TRANSACTION,
-    payload: LocalStore.setValue(PREFIX + address, updated)
+    payload: LocalStore.setValue(PREFIX + address + '_' + network, updated)
   }
 }
 
-export function saveTransactions (address: string, list: ITransaction[]): AnyAction {
+export function saveTransactions (address: string, network: string,
+    list: ITransaction[]): AnyAction {
   return {
     type: ACTION_TYPES.SAVE_TRANSACTIONS,
-    payload: LocalStore.setValue(PREFIX + address, list)
+    payload: LocalStore.setValue(PREFIX + address + '_' + network, list)
   }
 }

--- a/src/ts/components/account/AccountDropdown.tsx
+++ b/src/ts/components/account/AccountDropdown.tsx
@@ -65,7 +65,7 @@ class AccountDropdown extends React.Component<IAccountDropdownProps, IAccountDro
       } })
 
       // load transactions for the selected account
-      this.props.getTransactions(dropdownOptions[0].value)
+      this.props.getTransactions(dropdownOptions[0].value, this.props.settings.network)
     }
   }
 
@@ -176,7 +176,7 @@ class AccountDropdown extends React.Component<IAccountDropdownProps, IAccountDro
   componentDidMount () {
     if (this.props.settings.selectedAccount) {
       const account = this.props.settings.selectedAccount
-      this.props.getTransactions(account.address)
+      this.props.getTransactions(account.address, this.props.settings.network)
     }
   }
 

--- a/src/ts/components/dashboard/TopMenu.tsx
+++ b/src/ts/components/dashboard/TopMenu.tsx
@@ -5,6 +5,7 @@ import { Image, Grid } from 'semantic-ui-react'
 import { networks } from '../../constants/networks'
 import { IAppState } from '../../background/store/all'
 import { saveSettings } from '../../background/store/settings'
+import { getTransactions } from '../../background/store/transaction'
 import { ChainDropdown } from '../basic-components'
 import SettingsMenu from './SettingsMenu'
 
@@ -31,6 +32,12 @@ class TopMenu extends React.Component<ITopMenuProps, ITopMenuState> {
       chainIconUrl: networks[data.value].chain.iconUrl
     })
     this.props.saveSettings({ ...this.props.settings, network: data.value })
+
+    // load transactions for the selected network
+    if (this.props.settings.selectedAccount) {
+      this.props.getTransactions(this.props.settings.selectedAccount.address, data.value)
+    }
+
   }
 
   handleProfileIconClick = () => {
@@ -115,7 +122,7 @@ const mapStateToProps = (state: IAppState) => {
 
 type StateProps = ReturnType<typeof mapStateToProps>
 
-const mapDispatchToProps = { saveSettings }
+const mapDispatchToProps = { saveSettings, getTransactions }
 
 type DispatchProps = typeof mapDispatchToProps
 

--- a/src/ts/components/dashboard/TransactionList.tsx
+++ b/src/ts/components/dashboard/TransactionList.tsx
@@ -45,7 +45,7 @@ class TransactionList extends React.Component<ITransactionListProps, ITransactio
 
   private loadTransactions = () => {
     // load the transaction list
-    if (this.state.currentAddress && this.state.currentAddress) {
+    if (this.state.currentAddress && this.state.currentNetwork) {
       console.log('Getting transactions for ' + this.state.currentAddress)
       this.props.getTransactions(this.state.currentAddress, this.state.currentNetwork)
     }

--- a/src/ts/components/dashboard/TransactionList.tsx
+++ b/src/ts/components/dashboard/TransactionList.tsx
@@ -26,7 +26,7 @@ class TransactionList extends React.Component<ITransactionListProps, ITransactio
     if (nextProps.account && nextProps.account.address !== prevState.currentAddress) {
       return { currentAddress: nextProps.account.address }
     } else if (nextProps.network !== prevState.currentNetwork) {
-      return { currentAddress: nextProps.network }
+      return { currentNetwork: nextProps.network }
     } else {
       return null
     }

--- a/src/ts/components/dashboard/TransactionList.tsx
+++ b/src/ts/components/dashboard/TransactionList.tsx
@@ -11,25 +11,30 @@ import { displayAddress } from '../../services/address-transformer'
 interface ITransactionListProps extends StateProps, DispatchProps, RouteComponentProps {}
 
 interface ITransactionListState {
-  currentAddress: string
+  currentAddress: string,
+  currentNetwork: string
 }
 
 class TransactionList extends React.Component<ITransactionListProps, ITransactionListState> {
 
   state = {
-    currentAddress: ''
+    currentAddress: '',
+    currentNetwork: ''
   }
 
   static getDerivedStateFromProps (nextProps, prevState) {
     if (nextProps.account && nextProps.account.address !== prevState.currentAddress) {
       return { currentAddress: nextProps.account.address }
+    } else if (nextProps.network !== prevState.currentNetwork) {
+      return { currentAddress: nextProps.network }
     } else {
       return null
     }
   }
 
   componentDidUpdate (_prevProps, prevState) {
-    if (prevState.currentAddress !== this.state.currentAddress) {
+    if (prevState.currentNetwork !== this.state.currentNetwork
+        || prevState.currentAddress !== this.state.currentAddress) {
       this.loadTransactions()
     }
   }
@@ -40,9 +45,9 @@ class TransactionList extends React.Component<ITransactionListProps, ITransactio
 
   private loadTransactions = () => {
     // load the transaction list
-    if (this.state.currentAddress) {
+    if (this.state.currentAddress && this.state.currentAddress) {
       console.log('Getting transactions for ' + this.state.currentAddress)
-      this.props.getTransactions(this.state.currentAddress)
+      this.props.getTransactions(this.state.currentAddress, this.state.currentNetwork)
     }
   }
 

--- a/src/ts/components/transaction/Send.tsx
+++ b/src/ts/components/transaction/Send.tsx
@@ -213,6 +213,7 @@ class Send extends React.Component<ISendProps, ISendState> {
 
     this.props.upsertTransaction(
       address,
+      this.props.settings.network,
       txItem,
       this.props.transactions
     )
@@ -232,10 +233,12 @@ class Send extends React.Component<ISendProps, ISendState> {
           // TODO: const the value
           if (method === 'ExtrinsicSuccess') {
             txItem.status = 'Success'
-            this.props.upsertTransaction(address, txItem, this.props.transactions)
+            this.props.upsertTransaction(address, this.props.settings.network,
+              txItem, this.props.transactions)
           } else if (method === 'ExtrinsicFailed') {
             txItem.status = 'Failure'
-            this.props.upsertTransaction(address, txItem, this.props.transactions)
+            this.props.upsertTransaction(address, this.props.settings.network,
+              txItem, this.props.transactions)
           }
         })
         done && done()
@@ -247,7 +250,8 @@ class Send extends React.Component<ISendProps, ISendState> {
         this.setState({ isLoading: false })
         txItem.status = 'Failure'
         txItem.updateTime = new Date().getTime()
-        this.props.upsertTransaction(address, txItem, this.props.transactions)
+        this.props.upsertTransaction(address, this.props.settings.network,
+          txItem, this.props.transactions)
         this.props.setError('Failed to send the transaction')
         if (!this.state.isTimeout) {
           clearTimeout(sendTimer)
@@ -258,7 +262,8 @@ class Send extends React.Component<ISendProps, ISendState> {
       txItem.status = 'Failure'
       this.setState({ isLoading: false })
       txItem.updateTime = new Date().getTime()
-      this.props.upsertTransaction(address, txItem, this.props.transactions)
+      this.props.upsertTransaction(address, this.props.settings.network,
+        txItem, this.props.transactions)
       this.props.setError('Failed to send the transaction')
       if (!this.state.isTimeout) {
         clearTimeout(sendTimer)


### PR DESCRIPTION
Tested with Alexander transaction. By switching to Kusama CC1 it updates the transaction list to be empty (no transactions).

Alexander network
![image](https://user-images.githubusercontent.com/4987280/70420251-6db4e680-1abb-11ea-9d24-e37af661d27d.png)

Kusama CC1
![image](https://user-images.githubusercontent.com/4987280/70420275-81f8e380-1abb-11ea-9c46-1ad8f51de962.png)
